### PR TITLE
Feature/bump min required py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = [
 authors = [
     {name = "Nejc Jurkovic", email = "kandelabr@gmail.com" }
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numpy",
     "scipy",

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,6 @@
 envlist = py38, py39, py310, py311, typing, analysis
 skipsdist=True
 
-[travis]
-python =
-    3.10: py310
-    3.11: py311
-
 [testenv]
 deps =
     .[dev]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310, py311, typing, analysis
+envlist = py38, py39, py310, py311, typing, analysis
 skipsdist=True
 
 [travis]


### PR DESCRIPTION
I suggest we bump minimum required python version to 3.8, as [`Literal`](https://docs.python.org/3/library/typing.html#typing.Literal) is only supported from there on. That means, deprecating python 3.7, where tests are no longer (and never really were) runnable.

I wonder how many users out there this change will impact.

