### PR TITLE
Relations introspection in chop

### DIFF
--- a/src/classy_blocks/grading/chop.py
+++ b/src/classy_blocks/grading/chop.py
@@ -1,4 +1,5 @@
 import dataclasses
+from functools import lru_cache
 from typing import Callable, List, Optional, Set, Tuple, Union
 
 from classy_blocks.grading import relations as rel
@@ -37,6 +38,7 @@ class ChopRelation:
             raise RuntimeError(f"Invalid function name or unexpected parameter names: {function.__name__}") from err
 
     @staticmethod
+    @lru_cache(maxsize=1)
     def get_possible_combinations() -> List["ChopRelation"]:
         calculation_functions = rel.get_calculation_functions()
 

--- a/src/classy_blocks/grading/chop.py
+++ b/src/classy_blocks/grading/chop.py
@@ -89,10 +89,10 @@ class Chop:
 
                 return count, total_expansion
 
-            for crel in ChopRelation.get_possible_combinations():
-                output = crel.output
-                inputs = crel.inputs
-                function = crel.function
+            for chop_rel in ChopRelation.get_possible_combinations():
+                output = chop_rel.output
+                inputs = chop_rel.inputs
+                function = chop_rel.function
 
                 if output in calculated:
                     # this value is already calculated, go on
@@ -100,7 +100,7 @@ class Chop:
 
                 if inputs.issubset(calculated):
                     # value is not yet calculated but parameters are available
-                    data[output] = function(length, data[crel.input_1], data[crel.input_2])
+                    data[output] = function(length, data[chop_rel.input_1], data[chop_rel.input_2])
                     calculated.add(output)
 
         raise ValueError(f"Could not calculate count and grading for given parameters: {data}")

--- a/src/classy_blocks/grading/relations.py
+++ b/src/classy_blocks/grading/relations.py
@@ -1,3 +1,7 @@
+import inspect
+import sys
+from typing import Callable, Dict
+
 import numpy as np
 import scipy.optimize
 
@@ -182,3 +186,14 @@ def get_total_expansion__start_size__end_size(length, start_size, end_size):
     assert end_size > 0
 
     return end_size / start_size
+
+
+def get_calculation_functions() -> Dict[str, Callable]:
+    # gather available functions for calculation of grading parameters
+    functions = dict()
+    for name, function in inspect.getmembers(sys.modules[__name__], inspect.isfunction):
+        if name.startswith("get_"):
+            if "__" in name:
+                functions[name] = function
+
+    return functions

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -3,7 +3,7 @@ import unittest
 from parameterized import parameterized
 
 from classy_blocks.grading import relations as rel
-from classy_blocks.grading.chop import Chop, ChopRelation, functions
+from classy_blocks.grading.chop import Chop, ChopRelation
 from classy_blocks.grading.grading import Grading
 
 
@@ -27,10 +27,9 @@ class TestGrading(unittest.TestCase):
             ["total_expansion", ["count", "c2c_expansion"], rel.get_total_expansion__count__c2c_expansion],
             ["total_expansion", ["start_size", "end_size"], rel.get_total_expansion__start_size__end_size],
         ]
-
         expected_functions = [ChopRelation(f[0], f[1][0], f[1][1], f[2]) for f in expected_functions]
 
-        self.assertListEqual(expected_functions, functions)
+        self.assertCountEqual(expected_functions, ChopRelation.get_possible_combinations())
 
     @parameterized.expand(
         (


### PR DESCRIPTION
First step, just to remove problematic module introspection in [_src/classy_blocks/chop.py_].(https://github.com/damogranlabs/classy_blocks/blob/852c920b2628f41c4d0040c18131df7abee5e5d3/src/classy_blocks/grading/chop.py#L38) 

With this approach, user can still access calculation functions, but other modules can fetch a list of calculation functions via specific getter, that is  [`relations.get_calculation_functions()`](https://github.com/damogranlabs/classy_blocks/blob/5cd4ff7c586f7bb6e384e7fa206b34320babe6c2/src/classy_blocks/grading/relations.py#L191). Furthermore, one construct all chop relation classes with staticmethod:  [`chop.ChopRelation.get_possible_combinations()`](https://github.com/damogranlabs/classy_blocks/blob/5cd4ff7c586f7bb6e384e7fa206b34320babe6c2/src/classy_blocks/grading/chop.py#L40).

This is just a pre-condition to enable further assert refactoring. What do u say?