### PR TITLE
bug fix in the grid for SplineDisk

### DIFF
--- a/src/classy_blocks/construct/flat/sketches/spline_round.py
+++ b/src/classy_blocks/construct/flat/sketches/spline_round.py
@@ -337,7 +337,8 @@ class SplineDisk(HalfSplineDisk):
     @property
     def grid(self) -> List[List[Face]]:
         if len(self.faces) > 6:
-            return [self.faces[:4], self.faces[4:]]
+            return [self.faces[::3],
+                    [face for i, face in enumerate(self.faces) if not i % 3 == 0]]
         else:
             return super().grid
 


### PR DESCRIPTION
I found a small mistake in the grid property in SplineDisk, causing the core and shell property to give wrong results