### PR TITLE
Add py3.12 to Github actions and tox config

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -6,7 +6,7 @@ jobs:
     pytests:
         strategy:
             matrix:
-                python-version: ["3.8", "3.9", "3.10", "3.11"]
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
             fail-fast: false
         runs-on: ubuntu-latest
         steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, analysis
+envlist = py38, py39, py310, py311, py312, analysis
 
 [testenv]
 deps =


### PR DESCRIPTION
Include Python 3.12 in pytests (tox and Github actions)