### PR TITLE
Refactor splined ring sketches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ dmypy.json
 # IDEs on hold
 .idea
 .vscode
+
+# Mac specific
+.DS_Store

--- a/examples/shape/splined/spline_ring_whole_half_quarter.py
+++ b/examples/shape/splined/spline_ring_whole_half_quarter.py
@@ -1,0 +1,25 @@
+import os
+
+import classy_blocks as cb
+
+mesh = cb.Mesh()
+
+quarter_ring_sketch = cb.QuarterSplineRing([0, 0, 0], [1.0, 0, 0], [0, 1.0, 0], 0.1, 0.2, 0.8, 0.8)
+half_ring_sketch = cb.HalfSplineRing([0, 0, 0], [1.0, 0, 0], [0, 1.0, 0], 0.1, 0.2, 0.8, 0.8)
+whole_ring_sketch = cb.SplineRing([0, 0, 0], [1.0, 0, 0], [0, 1.0, 0], 0.1, 0.2, 0.8, 0.8)
+
+sketches = [quarter_ring_sketch, half_ring_sketch, whole_ring_sketch]
+
+extruded_shapes = []
+
+for i, sketch in enumerate(sketches):
+    extruded_shapes.append(cb.ExtrudedShape(sketch, 1))
+    extruded_shapes[i].translate([0, 0, i * 3])
+
+    for operation in extruded_shapes[i].operations:
+        for j in range(3):
+            operation.chop(j, count=10)
+
+    mesh.add(extruded_shapes[i])
+
+mesh.write(os.path.join("..", "..", "case", "system", "blockMeshDict"), debug_path="debug.vtk")

--- a/src/classy_blocks/construct/flat/sketches/disk.py
+++ b/src/classy_blocks/construct/flat/sketches/disk.py
@@ -285,8 +285,8 @@ class HalfDisk(DiskBase):
         ratios = [self.core_ratio, self.diagonal_ratio]
         angles = np.linspace(0, np.pi, num=5)
 
-        super().__init__(
-            [center_point, *pattern.get_inner_points(angles, ratios), *pattern.get_outer_points(angles)], quad_map
+        DiskBase.__init__(
+            self, [center_point, *pattern.get_inner_points(angles, ratios), *pattern.get_outer_points(angles)], quad_map
         )
 
     @property
@@ -322,8 +322,8 @@ class FourCoreDisk(DiskBase):
         ratios = [self.core_ratio, self.diagonal_ratio]
         angles = np.linspace(0, 2 * np.pi, num=8, endpoint=False)
 
-        super().__init__(
-            [center_point, *pattern.get_inner_points(angles, ratios), *pattern.get_outer_points(angles)], quad_map
+        DiskBase.__init__(
+            self, [center_point, *pattern.get_inner_points(angles, ratios), *pattern.get_outer_points(angles)], quad_map
         )
 
     @property

--- a/src/classy_blocks/construct/flat/sketches/spline_round.py
+++ b/src/classy_blocks/construct/flat/sketches/spline_round.py
@@ -388,7 +388,6 @@ class HalfSplineDisk(SplineRound, HalfDisk):
             side_2: Straight length for oval shape
         """
         SplineRound.__init__(self, side_1, side_2, **kwargs)
-        HalfDisk.__init__(self, center_point, corner_1_point, normal=self.u_0)
 
         corner_1_point = np.asarray(corner_1_point)
         corner_2_point = np.asarray(corner_2_point)
@@ -464,7 +463,6 @@ class SplineDisk(SplineRound, FourCoreDisk):
             side_2: Straight length for oval shape
         """
         SplineRound.__init__(self, side_1, side_2, **kwargs)
-        FourCoreDisk.__init__(self, center_point, corner_1_point, normal=self.u_0)
 
         corner_1_point = np.asarray(corner_1_point)
         corner_2_point = np.asarray(corner_2_point)

--- a/src/classy_blocks/construct/flat/sketches/spline_round.py
+++ b/src/classy_blocks/construct/flat/sketches/spline_round.py
@@ -387,7 +387,8 @@ class HalfSplineDisk(SplineRound, HalfDisk):
             side_1: Straight length for oval shape
             side_2: Straight length for oval shape
         """
-        super().__init__(side_1, side_2, **kwargs)
+        SplineRound.__init__(self, side_1, side_2, **kwargs)
+        HalfDisk.__init__(self, center_point, corner_1_point, normal=self.u_0)
 
         corner_1_point = np.asarray(corner_1_point)
         corner_2_point = np.asarray(corner_2_point)
@@ -396,7 +397,7 @@ class HalfSplineDisk(SplineRound, HalfDisk):
 
         # Create a HalfDisk
         self.disk_initialized = False
-        super(SplineRound, self).__init__(center_point, corner_1_point, normal=self.u_0)
+        HalfDisk.__init__(self, center_point, corner_1_point, normal=self.u_0)
         self.disk_initialized = True
 
         # Adjust to actual shape
@@ -462,7 +463,8 @@ class SplineDisk(SplineRound, FourCoreDisk):
             side_1: Straight length for oval shape
             side_2: Straight length for oval shape
         """
-        super().__init__(side_1, side_2, **kwargs)
+        SplineRound.__init__(self, side_1, side_2, **kwargs)
+        FourCoreDisk.__init__(self, center_point, corner_1_point, normal=self.u_0)
 
         corner_1_point = np.asarray(corner_1_point)
         corner_2_point = np.asarray(corner_2_point)
@@ -471,7 +473,7 @@ class SplineDisk(SplineRound, FourCoreDisk):
 
         # Create a FourCoreDisk
         self.disk_initialized = False
-        super(SplineRound, self).__init__(center_point, corner_1_point, normal=self.u_0)
+        FourCoreDisk.__init__(self, center_point, corner_1_point, normal=self.u_0)
         self.disk_initialized = True
 
         # Adjust to actual shape
@@ -646,7 +648,7 @@ class QuarterSplineRing(QuarterSplineDisk):
         return None
 
 
-class HalfSplineRing(HalfSplineDisk):
+class HalfSplineRing(HalfSplineDisk, QuarterSplineRing):
     """Ring based on SplineRound."""
 
     chops: ClassVar = [
@@ -690,7 +692,7 @@ class HalfSplineRing(HalfSplineDisk):
             corner_1_point = corner_1_point + self.width_1 * self.u_1
             corner_2_point = corner_2_point + self.width_2 * self.u_2
 
-        super().__init__(center_point, corner_1_point, corner_2_point, side_1, side_2, **kwargs)
+        HalfSplineDisk.__init__(self, center_point, corner_1_point, corner_2_point, side_1, side_2, **kwargs)
 
     def correct_disk(self, corner_1_point: NPPointType, corner_2_point: NPPointType):
         """Method to convert a disk to a ring"""
@@ -758,7 +760,7 @@ class HalfSplineRing(HalfSplineDisk):
         return None
 
 
-class SplineRing(SplineDisk):
+class SplineRing(SplineDisk, QuarterSplineRing):
     """Ring based on SplineRound."""
 
     chops: ClassVar = [
@@ -802,7 +804,7 @@ class SplineRing(SplineDisk):
             corner_1_point = corner_1_point + self.width_1 * self.u_1
             corner_2_point = corner_2_point + self.width_2 * self.u_2
 
-        super().__init__(center_point, corner_1_point, corner_2_point, side_1, side_2, **kwargs)
+        SplineDisk.__init__(self, center_point, corner_1_point, corner_2_point, side_1, side_2, **kwargs)
 
     def correct_disk(self, corner_1_point: NPPointType, corner_2_point: NPPointType):
         """Method to convert a disk to a ring"""
@@ -841,36 +843,6 @@ class SplineRing(SplineDisk):
             - (self.side_2 + r_2 * np.sin(np.pi / 4)) * self.u_2
         )
         self.update(pos)
-
-    def add_edges(self) -> None:
-        # Don't run add_edges in QuarterDisk.__init__()
-        if not self.disk_initialized:
-            return
-
-        # Outside
-        # Circular
-        if (
-            self.side_1 < constants.TOL
-            and self.side_2 < constants.TOL
-            and abs(self.radius_1 - self.radius_2) < constants.TOL
-        ):
-            for face in self.shell:
-                face.add_edge(1, Origin(self.origo))
-        else:
-            self.add_outer_spline_edges()
-
-        # Inside
-        # Circular
-        if (
-            self.side_1 < constants.TOL
-            and self.side_2 < constants.TOL
-            and abs(self.radius_1 - self.radius_2) < constants.TOL
-            and abs(self.width_1 - self.width_2) < constants.TOL
-        ):
-            for face in self.shell:
-                face.add_edge(3, Origin(self.origo))
-        else:
-            self.add_inner_spline_edges()
 
     @property
     def grid(self):

--- a/src/classy_blocks/construct/flat/sketches/spline_round.py
+++ b/src/classy_blocks/construct/flat/sketches/spline_round.py
@@ -587,7 +587,7 @@ class QuarterSplineRing(QuarterSplineDisk):
         super().__init__(center_point, corner_1_point, corner_2_point, side_1, side_2, **kwargs)
 
     def correct_disk(self, corner_1_point: NPPointType, corner_2_point: NPPointType):
-        """Method to convert a disk to a ting"""
+        """Method to convert a disk to a ring"""
 
         # First adjust circular disk to SplineDisk
         super().correct_disk(corner_1_point, corner_2_point)
@@ -693,7 +693,7 @@ class HalfSplineRing(HalfSplineDisk):
         super().__init__(center_point, corner_1_point, corner_2_point, side_1, side_2, **kwargs)
 
     def correct_disk(self, corner_1_point: NPPointType, corner_2_point: NPPointType):
-        """Method to convert a disk to a ting"""
+        """Method to convert a disk to a ring"""
 
         # First adjust circular disk to SplineDisk
         super().correct_disk(corner_1_point, corner_2_point)
@@ -805,7 +805,7 @@ class SplineRing(SplineDisk):
         super().__init__(center_point, corner_1_point, corner_2_point, side_1, side_2, **kwargs)
 
     def correct_disk(self, corner_1_point: NPPointType, corner_2_point: NPPointType):
-        """Method to convert a disk to a ting"""
+        """Method to convert a disk to a ring"""
 
         # First adjust circular disk to splinedisk
         super().correct_disk(corner_1_point, corner_2_point)


### PR DESCRIPTION
### This change resolves #53 "Refactored Splined Sketches"
Removes redundant add_edges method from two of the three derived ring classes and inherits the method from the remaining class that contains the method. Had to change some super.init and explicitly call the parent's constructor to make the change.

### Also made a few small changes:

- typo of ting changed to ring in the SplineRing, HalfSplineRing, and QuarterSplineRing class descriptions
- Added .DS_Store to the .gitignore
- Added an example file that creates a SplineRing, HalfSplineRing, and QuarterSplineRing in one mesh file
