### PR TITLE
Fix stack overflow in catalogue

### DIFF
--- a/src/classy_blocks/grading/analyze/catalogue.py
+++ b/src/classy_blocks/grading/analyze/catalogue.py
@@ -57,20 +57,25 @@ class RowCatalogue:
         raise NoInstructionError(f"No instruction found for block {block}")
 
     def _add_block_to_row(self, row: Row, instruction: Instruction, direction: DirectionType) -> None:
-        row.add_block(instruction.block, direction)
-        instruction.directions[direction] = True
+        tasks = [(instruction, direction)]
 
-        block = instruction.block
+        while tasks:
+            current_instruction, current_direction = tasks.pop()
 
-        for neighbour_axis in block.axes[direction].neighbours:
-            neighbour_block = get_block_from_axis(self.block_list, neighbour_axis)
-
-            if neighbour_block in row.blocks:
+            if current_instruction.block in row.blocks:
                 continue
 
-            instruction = self._find_instruction(neighbour_block)
+            row.add_block(current_instruction.block, current_direction)
+            current_instruction.directions[current_direction] = True
 
-            self._add_block_to_row(row, instruction, neighbour_block.get_axis_direction(neighbour_axis))
+            block = current_instruction.block
+
+            for neighbour_axis in block.axes[current_direction].neighbours:
+                neighbour_block = get_block_from_axis(self.block_list, neighbour_axis)
+
+                neighbour_instruction = self._find_instruction(neighbour_block)
+
+                tasks.append((neighbour_instruction, neighbour_block.get_axis_direction(neighbour_axis)))
 
     def _populate(self, direction: DirectionType) -> None:
         while True:


### PR DESCRIPTION
Meshes with 200x200 hexahedra trigger a StackOverflow when initializing the RowCatalogue.

This PR is a simple conversion to a stack-based implementation.

The error I get:

```
    grader = cb.FixedCountGrader(mesh, count=1)
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/graders/fixed.py", line 27, in __init__
    super().__init__(mesh.dump, mesh.settings)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/graders/manager.py", line 262, in __init__
    self.probe = Probe(dump, settings)
                 ~~~~~^^^^^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/probe.py", line 155, in __init__
    self.rows = RowCatalogue(dump.block_list)
                ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/catalogue.py", line 46, in __init__
    self._populate(i)
    ~~~~~~~~~~~~~~^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/catalogue.py", line 82, in _populate
    self._add_block_to_row(row, undefined_instructions[0], direction)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/catalogue.py", line 73, in _add_block_to_row
    self._add_block_to_row(row, instruction, neighbour_block.get_axis_direction(neighbour_axis))
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/catalogue.py", line 73, in _add_block_to_row
    self._add_block_to_row(row, instruction, neighbour_block.get_axis_direction(neighbour_axis))
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/catalogue.py", line 73, in _add_block_to_row
    self._add_block_to_row(row, instruction, neighbour_block.get_axis_direction(neighbour_axis))
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [Previous line repeated 986 more times]
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/catalogue.py", line 60, in _add_block_to_row
    row.add_block(instruction.block, direction)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/grading/analyze/row.py", line 64, in add_block
    flipped = not entry.axis.is_aligned(axis)
                  ~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/items/wires/axis.py", line 42, in is_aligned
    return this_wire.is_aligned(other_wire)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "venv/lib/python3.14/site-packages/classy_blocks/items/wires/wire.py", line 71, in is_aligned
    if not self.is_coincident(candidate):
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```

Thanks for this great tool BTW!