### PR TITLE
Add explicit `float`type  annotation for variable

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -10,9 +10,9 @@ jobs:
             fail-fast: false
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v7
             -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v4
+                uses: actions/setup-python@v7
                 with:
                     python-version: ${{ matrix.python-version }}
             -   name: Install dependencies
@@ -25,9 +25,9 @@ jobs:
     Analysis:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v7
             -   name: Set up Python 3.13
-                uses: actions/setup-python@v4
+                uses: actions/setup-python@v7
                 with:
                     python-version: "3.13"
             -   name: Install dependencies

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -5,6 +5,10 @@ on: [ push ]
 permissions:
     contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     pytests:
         strategy:

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -1,6 +1,11 @@
 name: Test and analyze
 
-on: [ push ]
+# push: safety net for direct pushes to protected branches.
+# pull_request: gates PRs against a merge commit (branch + target), not just the branch alone.
+on:
+    push:
+        branches: [ development, release, master ]
+    pull_request:
 
 permissions:
     contents: read

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -2,6 +2,9 @@ name: Test and analyze
 
 on: [ push ]
 
+permissions:
+    contents: read
+
 jobs:
     pytests:
         strategy:

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -15,6 +15,7 @@ jobs:
                 uses: actions/setup-python@v7
                 with:
                     python-version: ${{ matrix.python-version }}
+                    cache: pip
             -   name: Install dependencies
                 run: |
                     python -m pip install -U pip tox
@@ -30,6 +31,7 @@ jobs:
                 uses: actions/setup-python@v7
                 with:
                     python-version: "3.13"
+                    cache: pip
             -   name: Install dependencies
                 run: |
                     python -m pip install -U pip tox

--- a/src/classy_blocks/optimize/quality.py
+++ b/src/classy_blocks/optimize/quality.py
@@ -112,7 +112,7 @@ def get_quad_inner_angle(points: NPPointListType, normal: NPVectorType, corner: 
 
 @numba.jit(nopython=True, cache=True)
 def get_quad_quality(grid_points: NPPointListType, cell_indexes: NPIndexType) -> float:
-    quality = 0
+    quality: float = 0
     quad_points = take(grid_points, cell_indexes)
     center, normal, aspect = get_quad_normal(quad_points)
 
@@ -135,7 +135,7 @@ def get_hex_quality(grid_points: NPPointListType, cell_indexes: NPIndexType) -> 
 
     side_indexes = np.array([[0, 1, 2, 3], [7, 6, 5, 4], [4, 0, 3, 7], [6, 2, 1, 5], [0, 4, 5, 1], [7, 3, 2, 6]])
 
-    quality = 0
+    quality: float = 0
 
     for side in side_indexes:
         # Non-ortho angle in a hexahedron is measured between two vectors:


### PR DESCRIPTION
Don't change variable type during runtime - `quality` is defined as `int`, but we write `float` during function execution. Works in python for these specific types, but could be dangerous for other types.