### PR TITLE
Kill stale CI job runs on new pushes

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -5,6 +5,10 @@ on: [ push ]
 permissions:
     contents: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     pytests:
         strategy:


### PR DESCRIPTION
This will kill existing CI jobs on any new push. Might not be what you actually want - If you intentionally do multiple pushes to test intermediate state, next push might cancel the job and you won't get results. Speed up the common "oh, push another small thing I forgot" though.