### PR TITLE
Fix inside-out blocks from rotation in the direction opposite to face winding

### DIFF
--- a/src/classy_blocks/construct/operations/revolve.py
+++ b/src/classy_blocks/construct/operations/revolve.py
@@ -2,6 +2,7 @@ from classy_blocks.cbtyping import VectorType
 from classy_blocks.construct import edges
 from classy_blocks.construct.flat.face import Face
 from classy_blocks.construct.operations.loft import Loft
+from classy_blocks.util import functions as f
 
 
 class Revolve(Loft):
@@ -19,9 +20,16 @@ class Revolve(Loft):
 
         bottom_face = base
         top_face = base.copy().rotate(angle, axis, origin)
+        side_angle = angle
+
+        # rotation opposite to the base face's winding creates an
+        # inside-out block (the same mechanism as with mirroring)
+        if f.is_loft_inverted(bottom_face.point_array, top_face.point_array):
+            bottom_face, top_face = top_face, bottom_face
+            side_angle = -side_angle
 
         super().__init__(bottom_face, top_face)
 
         # there are 4 side edges: the simplest is to use 'axis and angle'
         for i in range(4):
-            self.add_side_edge(i, edges.Angle(self.angle, self.axis))
+            self.add_side_edge(i, edges.Angle(side_angle, self.axis))

--- a/src/classy_blocks/construct/shape.py
+++ b/src/classy_blocks/construct/shape.py
@@ -1,6 +1,7 @@
 """Abstract base classes for different Shape types"""
 
 import abc
+import warnings
 from typing import Generic, Optional, TypeVar, Union
 
 import numpy as np
@@ -72,6 +73,9 @@ class LoftedShape(Shape, abc.ABC, Generic[SketchT]):
         self.sketch_mid = sketch_mid
 
         self.lofts: list[list[Loft]] = []
+        # True when the end transform inverts the sketch winding
+        # (e.g. a rotation in the direction opposite to it)
+        self._inverted = False
 
         for i, list_1 in enumerate(self.sketch_1.grid):
             self.lofts.append([])
@@ -80,19 +84,34 @@ class LoftedShape(Shape, abc.ABC, Generic[SketchT]):
                 face_2 = self.sketch_2.grid[i][j]
 
                 mid_faces = [sketch.grid[i][j] for sketch in sketch_mid]
-                loft = Loft.from_series([face_1, *mid_faces, face_2])
+
+                series = [face_1, *mid_faces, face_2]
+                if f.is_loft_inverted(face_1.point_array, face_2.point_array):
+                    series = [face_2, *mid_faces, face_1]
+                    self._inverted = True
+
+                loft = Loft.from_series(series)
 
                 self.lofts[-1].append(loft)
 
+        if self._inverted:
+            warnings.warn(
+                "This shape's lofts were inside-out and have been auto-flipped "
+                "(start/end faces swapped) to keep blocks outward-facing.",
+                stacklevel=1,
+            )
+
     def set_start_patch(self, name: str) -> None:
         """Assign the faces of start sketch to a named patch"""
+        orient = "top" if self._inverted else "bottom"
         for operation in self.operations:
-            operation.set_patch("bottom", name)
+            operation.set_patch(orient, name)
 
     def set_end_patch(self, name: str) -> None:
         """Assign the faces of end sketch to a named patch"""
+        orient = "bottom" if self._inverted else "top"
         for operation in self.operations:
-            operation.set_patch("top", name)
+            operation.set_patch(orient, name)
 
     @property
     def operations(self):

--- a/src/classy_blocks/util/functions.py
+++ b/src/classy_blocks/util/functions.py
@@ -115,6 +115,26 @@ def scale(point: PointType, ratio: float, origin: Optional[PointType]) -> NPPoin
     return origin + (point - origin) * ratio
 
 
+def is_loft_inverted(bottom_points: PointListType, top_points: PointListType) -> bool:
+    """Whether a loft between two faces is wound inside-out
+    (the blockMesh 'Block is inside-out' condition)"""
+    points = np.concatenate(
+        (np.asarray(bottom_points, dtype=constants.DTYPE), np.asarray(top_points, dtype=constants.DTYPE))
+    )
+
+    # hex cell-model faces from OpenFOAM's etc/cellModels
+    faces = ((0, 4, 7, 3), (1, 2, 6, 5), (0, 1, 5, 4), (3, 7, 6, 2), (0, 3, 2, 1), (4, 5, 6, 7))
+
+    volume = 0.0
+
+    for face in faces:
+        face_points = points[list(face)]
+        area = 0.5 * sum(np.cross(face_points[i] - face_points[0], face_points[i + 1] - face_points[0]) for i in (1, 2))
+        volume += np.dot(face_points.mean(axis=0), area) / 3.0
+
+    return volume < 0
+
+
 def to_polar(point: PointType, axis: Literal["x", "z"] = "z") -> NPVectorType:
     """Convert (x, y, z) point to (radius, angle, height);
     the axis of the new polar coordinate system can be chosen ('x' or 'z')"""

--- a/tests/test_construct/test_rotation_orientation.py
+++ b/tests/test_construct/test_rotation_orientation.py
@@ -1,0 +1,139 @@
+import unittest
+import warnings
+
+import numpy as np
+from parameterized import parameterized
+
+import classy_blocks as cb
+from classy_blocks.construct.flat.face import Face
+from classy_blocks.construct.shapes.elbow import Elbow
+from classy_blocks.construct.shapes.rings import RevolvedRing
+from classy_blocks.construct.stack import RevolvedStack
+from classy_blocks.mesh import Mesh
+from classy_blocks.util import functions as f
+
+# hex cell-model faces from OpenFOAM's etc/cellModels
+HEX_FACES = ((0, 4, 7, 3), (1, 2, 6, 5), (0, 1, 5, 4), (3, 7, 6, 2), (0, 3, 2, 1), (4, 5, 6, 7))
+
+
+def face_area_vector(points):
+    """Area vector of a quad, fan from its first point (OpenFOAM rule)"""
+    p0 = points[0]
+    return 0.5 * sum(np.cross(points[i] - p0, points[i + 1] - p0) for i in (1, 2))
+
+
+def block_volumes(mesh):
+    """Signed volumes of all blocks; negative volume = inside-out block"""
+    mesh.assemble()
+
+    volumes = []
+
+    for block in mesh.blocks:
+        points = np.array([v.position for v in block.vertices])
+        volume = (
+            sum(np.dot(points[list(face)].mean(axis=0), face_area_vector(points[list(face)])) for face in HEX_FACES)
+            / 3.0
+        )
+        volumes.append(volume)
+
+    return volumes
+
+
+class RotationOrientationTests(unittest.TestCase):
+    def test_revolve_angle_directions(self):
+        """Blocks of a Revolve must be outward for both rotation directions"""
+        for angle in (np.pi / 3, -np.pi / 3):
+            mesh = Mesh()
+            base = Face([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], [cb.Arc([0.5, -0.2, 0]), None, None, None])
+            revolve = cb.Revolve(base, angle, [0, -1, 0], [-2, 0, 0])
+            revolve.chop(0, count=2)
+            revolve.chop(1, count=2)
+            revolve.chop(2, count=4)
+            mesh.add(revolve)
+
+            self.assertTrue(all(volume > 0 for volume in block_volumes(mesh)))
+
+    @parameterized.expand(
+        [
+            (np.pi / 3, 0.4),
+            (-np.pi / 3, 0.4),
+            (np.pi / 3, 1.5),
+            (-np.pi / 3, 1.5),
+        ]
+    )
+    def test_elbow_sweep_directions(self, sweep, radius_2):
+        """All blocks of an Elbow must be outward for both sweep directions"""
+        elbow = Elbow([0, 0, 0], [1, 0, 0], [0, 1, 0], sweep, [2, 0, 0], [0, 0, 1], radius_2)
+        elbow.chop_tangential(count=4)
+        elbow.chop_radial(count=2)
+        elbow.chop_axial(count=2)
+
+        mesh = Mesh()
+        mesh.add(elbow)
+
+        self.assertTrue(all(volume > 0 for volume in block_volumes(mesh)))
+
+    def test_revolved_ring_and_stack(self):
+        """Revolved shapes built on LoftedShape must be outward as well"""
+        ring = RevolvedRing([0, 0, 0], [1, 0, 0], Face([[0, 1, 0], [1, 1, 0], [1, 2, 0], [0, 2, 0]]), 8)
+
+        mesh = Mesh()
+        mesh.add(ring)
+        self.assertTrue(all(volume > 0 for volume in block_volumes(mesh)))
+
+        stack = RevolvedStack(cb.OneCoreDisk([0, 0, 0], [1, 0, 0], [0, 0, 1]), np.pi / 6, [0, 1, 0], [2, 0, 0], 4)
+
+        mesh = Mesh()
+        mesh.add(stack)
+        self.assertTrue(all(volume > 0 for volume in block_volumes(mesh)))
+
+    def test_translation_shapes_stay_outward(self):
+        """Translation-based shapes must not be touched by the correction"""
+        for solid in (cb.Box([0, 0, 0], [1, 1, 1]), cb.Cylinder([0, 0, 0], [0, 0, 1], [1, 0, 0])):
+            mesh = Mesh()
+            mesh.add(solid)
+            self.assertTrue(all(volume > 0 for volume in block_volumes(mesh)))
+
+    def test_revolve_side_arc_direction(self):
+        """The arc of a negative-angle Revolve sweeps the same sector as its positive twin"""
+        mesh = Mesh()
+        base = Face([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], [cb.Arc([0.5, -0.2, 0]), None, None, None])
+        revolve = cb.Revolve(base, -np.pi / 3, [0, -1, 0], [-2, 0, 0])
+        revolve.chop(0, count=1)
+        revolve.chop(1, count=1)
+        revolve.chop(2, count=1)
+        mesh.add(revolve)
+        mesh.assemble()
+
+        for wire in mesh.blocks[0].wires.get_axis_beams(2):
+            if set(wire.corners) == {0, 4}:
+                third_point = wire.edge.third_point.position
+                break
+        else:
+            self.fail("side edge not found")
+
+        expected = f.rotate(np.array([0, 0, 0]), -np.pi / 6, [0, -1, 0], [-2, 0, 0])
+        np.testing.assert_array_almost_equal(third_point, expected)
+
+    def test_elbow_start_end_patches(self):
+        """Start/end patches stay on the start/end faces for both sweep directions"""
+        for sweep in (np.pi / 3, -np.pi / 3):
+            elbow = Elbow([0, 0, 0], [1, 0, 0], [0, 1, 0], sweep, [2, 0, 0], [0, 0, 1], 0.4)
+            elbow.set_start_patch("inlet")
+            elbow.set_end_patch("outlet")
+
+            self.assertEqual(elbow.sketch_1.faces[0].patch_name, "inlet")
+            self.assertEqual(elbow.sketch_2.faces[0].patch_name, "outlet")
+
+    def test_auto_flip_warns(self):
+        """An inverting sweep warns about the auto-flip; a non-inverting one doesn't"""
+        # matches test_elbow_sweep_directions' inverting case: positive sweep
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Elbow([0, 0, 0], [1, 0, 0], [0, 1, 0], np.pi / 3, [2, 0, 0], [0, 0, 1], 0.4)
+        self.assertTrue(any("inside-out" in str(w.message) for w in caught))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Elbow([0, 0, 0], [1, 0, 0], [0, 1, 0], -np.pi / 3, [2, 0, 0], [0, 0, 1], 0.4)
+        self.assertFalse(any("inside-out" in str(w.message) for w in caught))


### PR DESCRIPTION
Rotation-based lofts write inside-out blocks whenever the rotation direction is opposite to the base face's winding, and blockMesh then aborts with "Block ... is inside-out". This reproduces with the shipped example parameters: `Elbow(..., sweep=+pi/3, ...)` inverts all 12 blocks and `Revolve(base, -pi/3, ...)` inverts its single block (negative-angle Revolve, issue #38, is the same root cause).

The fix follows the existing remedy for mirrored operations (`Operation.mirror()` swaps bottom and top faces): a rotation loft now swaps the two faces when the block's signed volume is negative, and negates the side-edge angle so the arcs keep their direction. The affected shapes (Elbow, RevolvedShape, RevolvedStack, RevolvedRing) keep start/end patches on their original faces.

Tests build both shipped examples plus their sign-flipped twins, the ring/stack/wedge variants and translation-based controls, and check that every block is outward (OpenFOAM `blockDescriptor::check` rule). They fail on the unpatched code; the full suite passes (1128 tests).
