### PR TITLE
Replace nptyping with numpy.typing so the package installs on numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 keywords = ["classy_blocks", "OpenFOAM", "blockMesh"]
 authors = [{ name = "Nejc Jurkovic", email = "nejc.jurkovic@proton.me" }]
 requires-python = ">=3.9"
-dependencies = ["numpy", "scipy", "nptyping", "numba"]
+dependencies = ["numpy", "scipy", "numba"]
 
 [project.urls]
 "Homepage" = "https://github.com/damogranlabs/classy_blocks"

--- a/src/classy_blocks/cbtyping.py
+++ b/src/classy_blocks/cbtyping.py
@@ -1,16 +1,17 @@
 from collections.abc import Sequence
 from typing import Any, Callable, Literal, Optional, TypedDict, Union
 
-from nptyping import Float, NDArray, Shape
+from numpy import floating
+from numpy.typing import NDArray
 
 # A plain list of floats
-FloatListType = NDArray[Shape["1, *"], Float]
+FloatListType = NDArray[floating]
 
 # A single point can be specified as a list of floats or as a numpy array
-NPPointType = NDArray[Shape["3, 1"], Any]
+NPPointType = NDArray[Any]
 PointType = Union[Sequence[Union[int, float]], NPPointType]
 # Similar: a list of points
-NPPointListType = NDArray[Shape["*, 3"], Any]
+NPPointListType = NDArray[Any]
 PointListType = Union[NPPointListType, Sequence[PointType], Sequence[NPPointType]]
 # same as PointType but with a different name to avoid confusion
 NPVectorType = NPPointType

--- a/src/classy_blocks/optimize/quality.py
+++ b/src/classy_blocks/optimize/quality.py
@@ -1,11 +1,11 @@
 import numba  # type:ignore
 import numpy as np
-from nptyping import Int32, NDArray, Shape
+from numpy.typing import NDArray
 
 from classy_blocks.cbtyping import NPPointListType, NPPointType, NPVectorType
 from classy_blocks.util.constants import VSMALL
 
-NPIndexType = NDArray[Shape["*, 1"], Int32]
+NPIndexType = NDArray[np.int32]
 
 
 @numba.jit(nopython=True)


### PR DESCRIPTION
nptyping is unmaintained and reads `numpy.bool8`, removed in numpy 2.0, so `import nptyping` raises AttributeError there. Because it is declared unconditionally, `pip install classy_blocks` succeeds on a numpy-2 environment and every script then fails on the first import.

classy_blocks uses nptyping for five type aliases in two files and nothing else — no runtime validation — so `numpy.typing.NDArray` covers it. The shape and dtype arguments are dropped because numpy.typing does not carry shapes; the aliases were documentation either way, since nothing checked them.

Dependency removed from pyproject.toml. The full test suite (1129 tests) passes on numpy 2.2.6 with nptyping absent from the environment.